### PR TITLE
Guess cachetool version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/config/steps/cachetool.yml
+++ b/config/steps/cachetool.yml
@@ -28,8 +28,7 @@
 
 - name: LEPHARE - Install cachetool {{ cachetool_version }}
   get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool-{{ cachetool_version }}.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
-  when: not cachetool_file.stat.exists and cachetool_version != 'latest'
-
+  when: cachetool_version != 'latest'
 
 - name: LEPHARE - Run cachetool opcache:reset
   shell: chdir={{ansistrano_release_path.stdout}}

--- a/config/steps/cachetool.yml
+++ b/config/steps/cachetool.yml
@@ -24,7 +24,7 @@
 
 - name: LEPHARE - Install cachetool
   get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
-  when: not cachetool_file.stat.exists and cachetool_version = 'latest'
+  when: not cachetool_file.stat.exists and cachetool_version == 'latest'
 
 - name: LEPHARE - Install cachetool
   get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool-{{ cachetool_version }}.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no

--- a/config/steps/cachetool.yml
+++ b/config/steps/cachetool.yml
@@ -11,24 +11,27 @@
       - cachetool_version is not defined
       - ansible_facts.packages['php'].version is version("7.2", ">=")
 
+- debug:
+    msg: PHP version is {{ ansible_facts.packages['php'].version  }}. cachetool@{{ ansible_facts.cachetool_version }} will be installed
+
 - name: LEPHARE - Check for cachetool.phar
   stat: path={{ lephare_cachetool_path }}
   register: cachetool_file
 
 - name: LEPHARE - Run cachetool self-update
   shell: "{{ lephare_cachetool_path }} self-update"
-  when: cachetool_file.stat.exists and lephare_cachetool_self_update and cachetool_version == 'latest'
+  when: cachetool_file.stat.exists and lephare_cachetool_self_update and ansible_facts.cachetool_version == 'latest'
   ignore_errors: True
   register: cachetool_self_update_result
   changed_when: cachetool_self_update_result.stderr
 
 - name: LEPHARE - Install cachetool
   get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
-  when: not cachetool_file.stat.exists and cachetool_version == 'latest'
+  when: not cachetool_file.stat.exists and ansible_facts.cachetool_version == 'latest'
 
 - name: LEPHARE - Install cachetool {{ cachetool_version }}
-  get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool-{{ cachetool_version }}.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
-  when: cachetool_version != 'latest'
+  get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool-{{ ansible_facts.cachetool_version }}.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
+  when: ansible_facts.cachetool_version != 'latest'
 
 - name: LEPHARE - Run cachetool opcache:reset
   shell: chdir={{ansistrano_release_path.stdout}}

--- a/config/steps/cachetool.yml
+++ b/config/steps/cachetool.yml
@@ -1,45 +1,21 @@
-- name: Gather thepackage facts
-  package_facts:
-    manager: auto
-
-- name: Print the package facts
-  debug:
-    var: ansible_facts.packages
-
-- set_fact:
-    cachetool_version: 4.1.1
-    when:
-      - cachetool_version is not defined
-      - ansible_facts.packages['php'].version is version("7.1", ">=")
-      - ansible_facts.packages['php'].version is version("7.2", "<")
-
-- set_fact:
-    cachetool_version: latest
-    when:
-      - cachetool_version is not defined
-      - ansible_facts.packages['php'].version is version("7.2", ">=")
-
-- debug:
-    msg: PHP version is {{ ansible_facts.packages['php'].version  }}. cachetool@{{ ansible_facts.cachetool_version }} will be installed
-
 - name: LEPHARE - Check for cachetool.phar
   stat: path={{ lephare_cachetool_path }}
   register: cachetool_file
 
 - name: LEPHARE - Run cachetool self-update
   shell: "{{ lephare_cachetool_path }} self-update"
-  when: cachetool_file.stat.exists and lephare_cachetool_self_update and ansible_facts.cachetool_version == 'latest'
+  when: cachetool_file.stat.exists and lephare_cachetool_self_update and lephare_cachetool_version == 'latest'
   ignore_errors: True
   register: cachetool_self_update_result
   changed_when: cachetool_self_update_result.stderr
 
 - name: LEPHARE - Install cachetool
   get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
-  when: not cachetool_file.stat.exists and ansible_facts.cachetool_version == 'latest'
+  when: not cachetool_file.stat.exists and lephare_cachetool_version == 'latest'
 
-- name: LEPHARE - Install cachetool {{ cachetool_version }}
-  get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool-{{ ansible_facts.cachetool_version }}.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
-  when: ansible_facts.cachetool_version != 'latest'
+- name: LEPHARE - Install cachetool {{ lephare_cachetool_version }}
+  get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool-{{ lephare_cachetool_version }}.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
+  when: lephare_cachetool_version != 'latest'
 
 - name: LEPHARE - Run cachetool opcache:reset
   shell: chdir={{ansistrano_release_path.stdout}}

--- a/config/steps/cachetool.yml
+++ b/config/steps/cachetool.yml
@@ -1,17 +1,35 @@
+- set_fact:
+    cachetool_version: 4.1.1
+    when:
+      - cachetool_version is not defined
+      - ansible_facts.packages['php'].version is version("7.1", ">=")
+      - ansible_facts.packages['php'].version is version("7.2", "<")
+
+- set_fact:
+    cachetool_version: latest
+    when:
+      - cachetool_version is not defined
+      - ansible_facts.packages['php'].version is version("7.2", ">=")
+
 - name: LEPHARE - Check for cachetool.phar
   stat: path={{ lephare_cachetool_path }}
   register: cachetool_file
 
 - name: LEPHARE - Run cachetool self-update
   shell: "{{ lephare_cachetool_path }} self-update"
-  when: cachetool_file.stat.exists and lephare_cachetool_self_update
+  when: cachetool_file.stat.exists and lephare_cachetool_self_update and cachetool_version = 'latest'
   ignore_errors: True
   register: cachetool_self_update_result
   changed_when: cachetool_self_update_result.stderr
 
 - name: LEPHARE - Install cachetool
   get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
-  when: not cachetool_file.stat.exists
+  when: not cachetool_file.stat.exists and cachetool_version = 'latest'
+
+- name: LEPHARE - Install cachetool
+  get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool-{{ cachetool_version }}.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
+  when: not cachetool_file.stat.exists and cachetool_version != 'latest'
+
 
 - name: LEPHARE - Run cachetool opcache:reset
   shell: chdir={{ansistrano_release_path.stdout}}

--- a/config/steps/cachetool.yml
+++ b/config/steps/cachetool.yml
@@ -1,3 +1,11 @@
+- name: Gather thepackage facts
+  package_facts:
+    manager: auto
+
+- name: Print the package facts
+  debug:
+    var: ansible_facts.packages
+
 - set_fact:
     cachetool_version: 4.1.1
     when:

--- a/config/steps/cachetool.yml
+++ b/config/steps/cachetool.yml
@@ -17,7 +17,7 @@
 
 - name: LEPHARE - Run cachetool self-update
   shell: "{{ lephare_cachetool_path }} self-update"
-  when: cachetool_file.stat.exists and lephare_cachetool_self_update and cachetool_version = 'latest'
+  when: cachetool_file.stat.exists and lephare_cachetool_self_update and cachetool_version == 'latest'
   ignore_errors: True
   register: cachetool_self_update_result
   changed_when: cachetool_self_update_result.stderr
@@ -26,7 +26,7 @@
   get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
   when: not cachetool_file.stat.exists and cachetool_version == 'latest'
 
-- name: LEPHARE - Install cachetool
+- name: LEPHARE - Install cachetool {{ cachetool_version }}
   get_url: url=http://gordalina.github.io/cachetool/downloads/cachetool-{{ cachetool_version }}.phar dest={{ lephare_cachetool_path }} mode=0755 validate_certs=no force=no
   when: not cachetool_file.stat.exists and cachetool_version != 'latest'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ lephare_cachetool_stat_clear: true
 lephare_cachetool_opcache_reset: true
 lephare_cachetool_apcu_clear: true
 lephare_cachetool_scheme: https
+lephare_cachetool_version: latest
 
 lephare_rollbar_notify: false
 lephare_sentry_notify: false

--- a/docker/roles.yml
+++ b/docker/roles.yml
@@ -1,5 +1,6 @@
 - src: https://github.com/erichard/ansible-db-pull
   name: db-pull
+
 - src: https://github.com/le-phare/ansible-deploy
   name: lephare.ansible-deploy
   version: master


### PR DESCRIPTION
Latest cachetool version requires php 7.2, for older versions we must use the given version : 

```
CacheTool 5.x works with PHP >=7.2
CacheTool 4.x works with PHP >=7.1
CacheTool 3.x works with PHP >=5.5.9
CacheTool 2.x works with PHP >=5.5.9
CacheTool 1.x works with PHP >=5.3.3
```
