### PR TITLE
feat(composer): allow to configure composer private registry auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Common deploy tasks for projects made at Le Phare.
   - [ansistrano.deploy](https://github.com/ansistrano/deploy)
   - [cbrunnkvist/ansistrano-symfony-deploy](https://github.com/cbrunnkvist/ansistrano-symfony-deploy)
 
+## Documentation
+
+* [Workflow overview](docs/workflow.md)
+* Composer:
+  * [Private registry](docs/composer/private-registry.md)
+
 ## Role Variables
 
 The defaults vars declared in this module:

--- a/config/before_composer.yml
+++ b/config/before_composer.yml
@@ -1,3 +1,6 @@
+- include_tasks: "../../lephare.ansible-deploy/config/steps/composer/private_registry.yml"
+  when: lephare_packagist_com_token is defined
+
 - name: Dump an existing database to a file (with compression)
   when: lephare_dump_database
   community.postgresql.postgresql_db:

--- a/config/steps/composer/private_registry.yml
+++ b/config/steps/composer/private_registry.yml
@@ -1,0 +1,14 @@
+- name: LEPHARE | COMPOSER | Ensure configuration directory exists
+  file:
+    path: "{{ composer_facts.home }}"
+    state: directory
+    recurse: yes
+    mode: 0755
+  register: composer_home_directory
+
+- name: LEPHARE | COMPOSER | Setup private registry
+  template:
+    src: auth.json.j2
+    dest: "{{ composer_facts.home }}/auth.json"
+    mode: 0600
+  when: lephare_packagist_com_token is defined

--- a/config/steps/gather_facts.yml
+++ b/config/steps/gather_facts.yml
@@ -11,3 +11,5 @@
     php_facts:
       version: "{{ php_version.stdout }}"
       extensions: "{{ php_extensions.stdout_lines }}"
+    composer_facts:
+      home: "{{ lookup('env', 'COMPOSER_HOME') | default('~/.composer', true) }}"

--- a/docs/composer/private-registry.md
+++ b/docs/composer/private-registry.md
@@ -1,0 +1,18 @@
+# Composer Private Registry
+
+## Conditions
+
+`lephare_packagist_com_token` must be set.
+
+## When
+
+During `lephare_symfony_before_composer_tasks_file`
+
+## Description
+
+Creates a `auth.json` file in the `COMPOSER_HOME` directory.
+
+## Known limitations
+
+- Only support `repo.packagist.com` for now.
+- Overwrite any existing `auth.json` file.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,83 @@
+```mermaid
+stateDiagram-v2
+    Setup --> UpdateCode
+    UpdateCode --> SymlinkShared
+    SymlinkShared --> SetupSymfony
+    SetupSymfony --> Symlink
+    Symlink --> Cleanup
+
+    state Setup {
+        ansistrano_before_setup_tasks_file --> ansistrano_after_setup_tasks_file
+    }
+
+    state UpdateCode {
+        ansistrano_before_update_code_tasks_file --> ansistrano_after_update_code_tasks_file
+    }
+
+    state SymlinkShared {
+        ansistrano_before_symlink_shared_tasks_file --> ansistrano_after_symlink_shared_tasks_file
+    }
+
+    state SetupSymfony {
+       Composer --> Assets
+       Assets --> Assetic
+       Assetic --> Cache
+       Cache --> Doctrine
+       Doctrine --> MongoDB
+    }
+
+    state Composer {
+       ansistrano_symfony_before_composer_tasks_file --> ansistrano_symfony_after_composer_tasks_file
+    }
+
+    state Assets {
+        ansistrano_symfony_before_assets_tasks_file --> ansistrano_symfony_after_assets_tasks_file
+    }
+
+    state Assetic {
+        ansistrano_symfony_before_assetic_tasks_file --> ansistrano_symfony_after_assetic_tasks_file
+    }
+
+    state Cache {
+        ansistrano_symfony_before_cache_tasks_file --> ansistrano_symfony_after_cache_tasks_file
+    }
+
+    state Doctrine {
+        ansistrano_symfony_before_doctrine_tasks_file --> ansistrano_symfony_after_doctrine_tasks_file
+    }
+
+    state MongoDB {
+        ansistrano_symfony_before_mongodb_tasks_file --> ansistrano_symfony_after_mongodb_tasks_file
+    }
+
+    state Symlink {
+        ansistrano_before_symlink_tasks_file --> ansistrano_after_symlink_tasks_file
+    }
+
+    state Cleanup {
+        ansistrano_before_cleanup_tasks_file --> ansistrano_after_cleanup_tasks_file
+    }
+
+    state ansistrano_before_symlink_tasks_file {
+        lephare_before_symlink_tasks_file
+    }
+
+    state lephare_before_symlink_tasks_file {
+        PublishAssets --> PreventIndexation
+        PreventIndexation --> Secure
+        Secure --> Adminer
+        Adminer --> Couscous
+    }
+
+    state ansistrano_after_symlink_tasks_file {
+        CacheTool --> Crontab
+        Crontab --> CloudfrontInvalidate
+        CloudfrontInvalidate --> RollbarNotify
+        RollbarNotify --> SentryNotify
+        SentryNotify --> Tideways
+        Tideways --> SlackNotify
+    }
+
+    state ansistrano_symfony_after_cache_tasks_file {
+        SetPermissions
+    }

--- a/templates/auth.json.j2
+++ b/templates/auth.json.j2
@@ -1,0 +1,12 @@
+{
+  "bitbucket-oauth": {},
+  "github-oauth": {},
+  "gitlab-oauth": {},
+  "gitlab-token": {},
+  "http-basic": {
+    "repo.packagist.com": {
+      "username": "token",
+      "password": "{{ lephare_packagist_com_token }}"
+    }
+  }
+}


### PR DESCRIPTION
# Composer Private Registry

## Conditions

`lephare_packagist_com_token` must be set.

## When

During `lephare_symfony_before_composer_tasks_file`

## Description

Creates a `auth.json` file in the `COMPOSER_HOME` directory.

## Known limitations

- Only support `repo.packagist.com` for now.
- Overwrite any existing `auth.json` file.

Fixes #19 
