### PR TITLE
feat: add support for symfony secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Common deploy tasks for projects made at Le Phare.
 * [Workflow overview](docs/workflow.md)
 * Composer:
   * [Private registry](docs/composer/private-registry.md)
+* Symfony:
+  * [Secrets](docs/symfony/secrets.md)
 
 ## Role Variables
 

--- a/config/before_composer.yml
+++ b/config/before_composer.yml
@@ -11,3 +11,10 @@
     login_password: "{{ app_database_password }}"
     state: dump
     target: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ db_pull_remote_database_name }}.sql.gz"
+
+- name: Setup {{ symfony_env }} secrets decrypt key
+  template:
+    src: symfony/secrets_private.php.j2
+    dest: "{{ ansistrano_release_path.stdout }}/config/secrets/{{ symfony_env }}/{{ symfony_env }}.decrypt.private.php"
+    mode: 0644
+  when: symfony_secret_private_key is defined

--- a/docs/symfony/secrets.md
+++ b/docs/symfony/secrets.md
@@ -1,0 +1,13 @@
+# Symfony secrets
+
+## Conditions
+
+`symfony_secret_private_key` must be set (in the vault).
+
+## When
+
+During `lephare_symfony_before_composer_tasks_file`
+
+## Description
+
+Creates a `decrypt.private.php` file in the `config/secret` directory allowing to use symfony secrets seamlessly.

--- a/templates/symfony/secrets_private.php.j2
+++ b/templates/symfony/secrets_private.php.j2
@@ -1,0 +1,3 @@
+<?php // {{ symfony_env }}.decrypt.private on {{ now(False, '%a, %d %b %Y %H:%M:%S %z') }}
+
+return "{{ symfony_secret_private_key }}";


### PR DESCRIPTION
Allow to generate `config/secrets/prod/prod.decrypt.private.php` from a vault stored variable.