### PR TITLE
fix: add sshpass package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.12.1](https://github.com/le-phare/ansible-deploy/compare/v1.12.0...v1.12.1) (2024-07-02)
+
+### Features
+
+* **Dockerfile:** add sshpass package ([#52](https://github.com/le-phare/ansible-deploy/pull/52))([todo](https://github.com/le-phare/ansible-deploy/pull/52/commits/todo))
+
 ## [1.12.0](https://github.com/le-phare/ansible-deploy/compare/v1.11.0...v1.12.0) (2024-07-02)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [1.12.1](https://github.com/le-phare/ansible-deploy/compare/v1.12.0...v1.12.1) (2024-07-02)
 
-### Features
+### Bug Fixes
 
-* **Dockerfile:** add sshpass package ([#52](https://github.com/le-phare/ansible-deploy/pull/52))([todo](https://github.com/le-phare/ansible-deploy/pull/52/commits/todo))
+* **Dockerfile:** add sshpass package ([#52](https://github.com/le-phare/ansible-deploy/pull/52))([72dd8ad](https://github.com/le-phare/ansible-deploy/pull/52/commits/72dd8ad064a212f3bca23396b738d1e9e0ce4665))
 
 ## [1.12.0](https://github.com/le-phare/ansible-deploy/compare/v1.11.0...v1.12.0) (2024-07-02)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV ANSIBLE_RETRY_FILES_ENABLED=false
 ENV ANSIBLE_STDOUT_CALLBACK=debug
 
 RUN apk add --no-cache --update bash git mysql-client openssh-client postgresql rsync
-RUN apk add --no-cache --virtual build-dependencies gcc libffi-dev musl-dev
+RUN apk add --no-cache --virtual build-dependencies gcc libffi-dev musl-dev sshpass
 
 RUN pip install --no-cache-dir ansible
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,8 @@ ENV ANSIBLE_PERSISTENT_CONTROL_PATH_DIR=/tmp/ansible-ssh-%%h-%%p-%%r
 ENV ANSIBLE_RETRY_FILES_ENABLED=false
 ENV ANSIBLE_STDOUT_CALLBACK=debug
 
-RUN apk add --no-cache --update bash git mysql-client openssh-client postgresql rsync
-RUN apk add --no-cache --virtual build-dependencies gcc libffi-dev musl-dev sshpass
+RUN apk add --no-cache --update bash git mysql-client openssh-client postgresql rsync sshpass
+RUN apk add --no-cache --virtual build-dependencies gcc libffi-dev musl-dev
 
 RUN pip install --no-cache-dir ansible
 


### PR DESCRIPTION
J'ai rencontré cette erreur en utilisant la version 1.12.0

> to use the 'ssh' connection type with passwords or pkcs11_provider, you must install the sshpass program

Je ne pense pas que ce soit lié au changement sur la 1.12.0 directement mais peut être indirectement au build de l'image Docker qui a été déclenché, sur laquelle le paquet ne serait plus présent depuis le dernier build (fin 2023) par défaut.

Je n'ai pas creusé plus. 