### PR TITLE
fix: set Ansible version to 2.15.4 to support Python2 and Python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.12.3](https://github.com/le-phare/ansible-deploy/compare/v1.12.2...v1.12.3) (2024-07-04)
+
+### Bug Fixes
+
+* **Ansible version:** fix Ansible version to 2.15.4  ([#todo](https://github.com/le-phare/ansible-deploy/pull/todo))([todo](https://github.com/le-phare/ansible-deploy/pull/todo/commits/todo))
+
 ## [1.12.2](https://github.com/le-phare/ansible-deploy/compare/v1.12.1...v1.12.2) (2024-07-04)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* **Ansible version:** fix Ansible version to 2.15.4  ([#todo](https://github.com/le-phare/ansible-deploy/pull/todo))([todo](https://github.com/le-phare/ansible-deploy/pull/todo/commits/todo))
+* **Ansible version:** fix Ansible version to 2.15.4  ([#todo](https://github.com/le-phare/ansible-deploy/pull/55))([4da1bf8](https://github.com/le-phare/ansible-deploy/pull/55/commits/4da1bf8a7a638d27a512fb204635569d83c1d84f))
 
 ## [1.12.2](https://github.com/le-phare/ansible-deploy/compare/v1.12.1...v1.12.2) (2024-07-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* **Ansible version:** fix Ansible version to 2.15.4  ([#todo](https://github.com/le-phare/ansible-deploy/pull/55))([4da1bf8](https://github.com/le-phare/ansible-deploy/pull/55/commits/4da1bf8a7a638d27a512fb204635569d83c1d84f))
+* **Ansible version:** fix Ansible version to 2.15.4  ([#55](https://github.com/le-phare/ansible-deploy/pull/55))([4da1bf8](https://github.com/le-phare/ansible-deploy/pull/55/commits/4da1bf8a7a638d27a512fb204635569d83c1d84f))
 
 ## [1.12.2](https://github.com/le-phare/ansible-deploy/compare/v1.12.1...v1.12.2) (2024-07-04)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Common deploy tasks for projects made at Le Phare.
   - [ansistrano.deploy](https://github.com/ansistrano/deploy)
   - [cbrunnkvist/ansistrano-symfony-deploy](https://github.com/cbrunnkvist/ansistrano-symfony-deploy)
 
+## Support matrix
+
+- lephare/ansible:1.12.3 - Ansible 2.15.4 - Python 2.7 or Python 3.5 - 3.11 (Control node)
+
+See [Ansible core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix)
+
 ## Documentation
 
 * [Workflow overview](docs/workflow.md)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV ANSIBLE_STDOUT_CALLBACK=debug
 RUN apk add --no-cache --update bash git mysql-client openssh-client postgresql rsync sshpass
 RUN apk add --no-cache --virtual build-dependencies gcc libffi-dev musl-dev
 
-RUN pip install --no-cache-dir ansible
+RUN pip install --no-cache-dir ansible ansible-core==2.15.4
 
 RUN apk del build-dependencies
 


### PR DESCRIPTION
Etant donné que la version d'Ansible dépendait du moment où le Docker build est fait, nous avons une version trop récente d'Ansible qui ne supporte plus Python2.

Nous comptons tag 1.12.3 et ensuite installer la dernière version d'Ansible avec le tag 2.0.

Nous complèterons le support matrix dans le README pour être clair