### PR TITLE
security: use forked install-composer to support channel installation

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - name: cbrunnkvist.ansistrano-symfony-deploy
     src: https://github.com/le-phare/ansistrano-symfony-deploy
-    version: install-composer
+    version: master
 
 galaxy_info:
   author: Erwan Richard

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 dependencies:
-  - { role: cbrunnkvist.ansistrano-symfony-deploy }
+  - name: cbrunnkvist.ansistrano-symfony-deploy
+    src: https://github.com/le-phare/ansistrano-symfony-deploy
+    version: install-composer
 
 galaxy_info:
   author: Erwan Richard


### PR DESCRIPTION
J'ai fait une [PR ](https://github.com/cbrunnkvist/ansistrano-symfony-deploy/pull/40)sur cbrunnkvist/ansistrano-symfony-deploy mais le projet n'est plus [maintenu](https://github.com/cbrunnkvist/ansistrano-symfony-deploy/issues/36).

Nous avons deux solutions:
- merge dans le fork lephare et utilisé ce fork dans ansible-deploy (donc version master et non install-composer)
- attendre ? Le projet n'a pas bougé depuis 4 ans 

Je suis pour changer les requirements de ansible-deploy pour utiliser notre fork.

Qu'en dites-vous ?


J'ai testé l'image docker les changements fonctionnent comme attendu.
