### PR TITLE
draft: fix: prune stale remote refs from cached repo before updating code

### DIFF
--- a/config/before_update_code.yml
+++ b/config/before_update_code.yml
@@ -1,0 +1,2 @@
+- include_tasks: "../../lephare.ansible-deploy/config/steps/git_remote_prune.yml"
+  when: lephare_git_remote_prune and ansistrano_deploy_via == 'git'

--- a/config/steps/git_remote_prune.yml
+++ b/config/steps/git_remote_prune.yml
@@ -1,0 +1,7 @@
+- name: LEPHARE - GIT - Prune stale remote refs in cached repository
+  command: git remote prune origin
+  args:
+    chdir: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir | default('repo') }}"
+    removes: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir | default('repo') }}/.git"
+  register: git_remote_prune
+  changed_when: git_remote_prune.stdout | length > 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,8 @@ lephare_cachetool_options: ""
 lephare_cachetool_retries: 10
 lephare_cachetool_delay: 15
 
+lephare_git_remote_prune: true
+
 lephare_gitlab_token: ""
 
 lephare_packagist_com_token: ""

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -12,6 +12,14 @@ stateDiagram-v2
 
     state UpdateCode {
         ansistrano_before_update_code_tasks_file --> ansistrano_after_update_code_tasks_file
+
+        state ansistrano_before_update_code_tasks_file {
+            lephare_before_update_code_tasks_file
+
+            state lephare_before_update_code_tasks_file {
+                GitRemotePrune
+            }
+        }
     }
 
     state SymlinkShared {

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 ansistrano_before_setup_tasks_file: "{{ lephare_before_setup_tasks_file | default('../../lephare.ansible-deploy/config/before_setup.yml') }}"
 ansistrano_after_symlink_tasks_file: "{{ lephare_after_symlink_tasks_file | default('../../lephare.ansible-deploy/config/after_symlink.yml') }}"
 ansistrano_before_symlink_tasks_file: "{{ lephare_before_symlink_tasks_file | default('../../lephare.ansible-deploy/config/before_symlink.yml') }}"
+ansistrano_before_update_code_tasks_file: "{{ lephare_before_update_code_tasks_file | default('../../lephare.ansible-deploy/config/before_update_code.yml') }}"
 
 ansistrano_symfony_after_cache_tasks_file: "{{ lephare_symfony_after_cache_tasks_file | default('../../lephare.ansible-deploy/config/after_cache.yml') }}"
 ansistrano_symfony_before_composer_tasks_file: "{{ lephare_symfony_before_composer_tasks_file | default('../../lephare.ansible-deploy/config/before_composer.yml') }}"


### PR DESCRIPTION
## Problème

Ansistrano met à jour le clone en cache (`{{ ansistrano_deploy_to }}/repo`) via le module `git` d'Ansible, qui fetche sans `--prune`. Les remote-tracking refs obsolètes ne sont donc **jamais** nettoyées.

Quand une branche est supprimée sur le remote puis qu'une nouvelle branche réutilise son nom comme préfixe de répertoire (ex. `test` supprimée, puis `test/foo` poussée), **tout** déploiement suivant sur cet hôte échoue :

```
error: cannot lock ref 'refs/remotes/origin/test/foo': 'refs/remotes/origin/test' exists; cannot create 'refs/remotes/origin/test/foo'
```

…jusqu'à ce que quelqu'un fasse un `git remote prune origin` manuel sur le serveur. Rencontré en prod aujourd'hui sur le staging imaprotect (`mvo2-api:deploy-staging`, image `lephare/ansible:2.1.0`).

C'est structurel : le module `git` d'ansible-core ne supporte pas d'option prune, la commande émise est exactement `git fetch --tags --force origin`. Git lui-même suggère le remède dans son message d'erreur (`try running 'git remote prune origin'`).

## Solution

Un step `git remote prune origin` branché via `ansistrano_before_update_code_tasks_file`, exécuté **avant** l'update-code (donc avant le fetch qui échoue) :

- stratégie git uniquement (`ansistrano_deploy_via == 'git'`) ;
- no-op tant que le repo en cache n'existe pas (`removes:` sur `.git`), donc sans effet au premier déploiement ;
- activé par défaut, opt-out via `lephare_git_remote_prune: false` ;
- les projets qui surchargent `lephare_before_update_code_tasks_file` le remplacent, cohérent avec les autres hooks (`before_setup`, `before_symlink`, …).

## Reproduction

```sh
git init --bare remote.git
git clone remote.git seed && cd seed
git commit --allow-empty -m init && git push origin HEAD:master && git push origin HEAD:test
cd .. && git clone remote.git cache && (cd cache && git fetch --tags --force origin)  # OK, origin/test en cache
cd seed && git push origin :test && git push origin HEAD:test/foo                       # test supprimée, test/foo créée
cd ../cache && git fetch --tags --force origin                                          # -> cannot lock ref
git remote prune origin && git fetch --tags --force origin                              # -> OK
```

Co-authored by Claude Code